### PR TITLE
Tooltip Extension

### DIFF
--- a/Bash Commander.xcodeproj/project.pbxproj
+++ b/Bash Commander.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		0AC7B60F255D55850052DAF9 /* EditCommandView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC7B60E255D55850052DAF9 /* EditCommandView.swift */; };
 		0AC7B614255D55CE0052DAF9 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC7B613255D55CE0052DAF9 /* HomeView.swift */; };
 		0AC7B638255D977D0052DAF9 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC7B637255D977D0052DAF9 /* Navigator.swift */; };
+		21CF9ABD2619CB39007C1BE5 /* TooltipExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CF9ABC2619CB39007C1BE5 /* TooltipExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -127,6 +128,7 @@
 		0AC7B60E255D55850052DAF9 /* EditCommandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCommandView.swift; sourceTree = "<group>"; };
 		0AC7B613255D55CE0052DAF9 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		0AC7B637255D977D0052DAF9 /* Navigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
+		21CF9ABC2619CB39007C1BE5 /* TooltipExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -272,6 +274,7 @@
 			isa = PBXGroup;
 			children = (
 				0A920C7325A4D3AE00B41641 /* ArrayExtensions.swift */,
+				21CF9ABC2619CB39007C1BE5 /* TooltipExtension.swift */,
 			);
 			path = utils;
 			sourceTree = "<group>";
@@ -523,6 +526,7 @@
 				0A278FCA25B6D947007D9F51 /* NotificationRepository.swift in Sources */,
 				0A3790E2255D3EDF00403E5C /* IconButton.swift in Sources */,
 				0A920C9625A4F81700B41641 /* OutputView.swift in Sources */,
+				21CF9ABD2619CB39007C1BE5 /* TooltipExtension.swift in Sources */,
 				0A920C8C25A4EA4D00B41641 /* DeleteCommand.swift in Sources */,
 				0A7FBB7A25A9FA3200193F3B /* AppConfig.swift in Sources */,
 				0A564229255C472B00607AA9 /* AppDelegate.swift in Sources */,

--- a/Bash Commander/presentation/home/CommandCard.swift
+++ b/Bash Commander/presentation/home/CommandCard.swift
@@ -40,6 +40,7 @@ struct CommandCard: View {
                 Spacer()
                 IconButton(name: "Edit", action: onMorePressed)
                 IconButton(name: "execute", action: onExecuteCommand)
+                    .tooltip(command.command ?? "")
             }
             .padding(/*@START_MENU_TOKEN@*/.all/*@END_MENU_TOKEN@*/, 8)
             .background(Color.card)

--- a/Bash Commander/presentation/new/EditCommandView.swift
+++ b/Bash Commander/presentation/new/EditCommandView.swift
@@ -100,6 +100,7 @@ struct EditCommandView: View {
                 HStack {
                     TextField("path", text: $path.animation()).disabled(true)
                         .textFieldStyle(MyTextStyle())
+                        .tooltip($path.wrappedValue)
                     IconButton(name: "more") {
                         let panel = NSOpenPanel()
                         panel.allowsMultipleSelection = false

--- a/Bash Commander/utils/TooltipExtension.swift
+++ b/Bash Commander/utils/TooltipExtension.swift
@@ -1,0 +1,60 @@
+//
+//  TooltipExtension.swift
+//  Bash Commander
+//
+//  Created by Wladislaw Tauberger on 04.04.21.
+//
+
+import Foundation
+import SwiftUI
+
+// This extension can be replaced with native swiftUI UI extension '.help("Tooltop text")'
+// The native extension needs macOS 11 as min. target
+
+extension View {
+    func tooltip(_ tip: String) -> some View {
+        background(GeometryReader { childGeometry in
+            TooltipView(tip, geometry: childGeometry) {
+                self
+            }
+        })
+    }
+}
+
+private struct TooltipView<Content>: View where Content: View {
+    let content: () -> Content
+    let tip: String
+    let geometry: GeometryProxy
+
+    init(_ tip: String, geometry: GeometryProxy, @ViewBuilder content: @escaping () -> Content) {
+        self.content = content
+        self.tip = tip
+        self.geometry = geometry
+    }
+
+    var body: some View {
+        Tooltip(tip, content: content)
+            .frame(width: geometry.size.width, height: geometry.size.height)
+    }
+}
+
+private struct Tooltip<Content: View>: NSViewRepresentable {
+    typealias NSViewType = NSHostingView<Content>
+
+    init(_ text: String?, @ViewBuilder content: () -> Content) {
+        self.text = text
+        self.content = content()
+    }
+
+    let text: String?
+    let content: Content
+
+    func makeNSView(context _: Context) -> NSHostingView<Content> {
+        NSViewType(rootView: content)
+    }
+
+    func updateNSView(_ nsView: NSHostingView<Content>, context _: Context) {
+        nsView.rootView = content
+        nsView.toolTip = text
+    }
+}


### PR DESCRIPTION
Added tooltip for path and a global extension to use it somewhere else. The extension will become obsolete if the min target will be raised to macOS 11.